### PR TITLE
Support custom use cases

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,41 @@ upload.on('progress', reportProgress);
 upload.on('end', done);
 ```
 
+### Upload#setPath(path)
+
+  Creates the xhr for the given path.  Calling `setPath` will setup the following:
+
+  * `upload.req` - xhr object
+  * `upload.body` - FormData
+
+### Upload#setParamName(name)
+
+  Use a parameter name other than `file` for your file.
+
+### Upload#start(fn)
+
+  Start the upload.
+
+## Custom example
+
+  If the defaults are not correct for you use case, you can modify your upload before starting:
+  In this example we have to include some extra information with our upload:
+
+  * the parameter name for the file is `audio` instead of `file`
+  * `upload.req` (the xhr) is accessed to set an Authorization header
+  * `upload.body` (the FormData) is accessed to append an additional form field
+
+```js
+var upload = new Upload(file);
+upload.setPath('https://uploads.example.com/');
+upload.setParamName('audio');
+upload.req.setRequestHeader('Authorization', myAuth);
+upload.body.append('templateId', 'some-uuid');
+upload.start(function() {
+  console.log('hooray!');
+});
+```
+
 ## Running tests
 
   Run the Express test server:

--- a/index.js
+++ b/index.js
@@ -49,13 +49,26 @@ Emitter(Upload.prototype);
 
 Upload.prototype.to = function(path, fn){
   // TODO: x-browser
-  var self = this;
-  fn = fn || function(){};
+  this.setPath(path);
+  this.start(fn);
+};
+
+Upload.prototype.setParamName = function(param) {
+  this.param = param;
+}
+
+Upload.prototype.setPath = function(path){
   var req = this.req = new XMLHttpRequest;
   req.open('POST', path);
   req.onload = this.onload.bind(this);
   req.onerror = this.onerror.bind(this);
   req.upload.onprogress = this.onprogress.bind(this);
+  this.body = new FormData;
+}
+
+Upload.prototype.start = function(fn) {
+  fn = fn || function(){};
+  var req = this.req;
   req.onreadystatechange = function(){
     if (4 == req.readyState) {
       var type = req.status / 100 | 0;
@@ -65,10 +78,10 @@ Upload.prototype.to = function(path, fn){
       fn(err);
     }
   };
-  var body = new FormData;
-  body.append('file', this.file);
-  req.send(body);
-};
+  var param = this.param || 'file';
+  this.body.append(param, this.file);
+  req.send(this.body);
+}
 
 /**
  * Abort the XHR.


### PR DESCRIPTION
- Ability to use a param name other than `file`
- Expose the xhr as `upload.req` to enable custom headers
- Expose the FormData as `upload.body` to enable additional form fields.
