### PR TITLE
Add X-Requested-With header

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -67,6 +66,7 @@ Upload.prototype.to = function(path, fn){
   };
   var body = new FormData;
   body.append('file', this.file);
+  req.setRequestHeader("X-Requested-With", "XMLHttpRequest");
   req.send(body);
 };
 


### PR DESCRIPTION
Sets the `X-Requested-With: XMLHttpRequest` header to allow server-side applications (e.g. express) to identify the request as XHR.
